### PR TITLE
Improve usability of predefined Money constructors

### DIFF
--- a/src/data/common.rs
+++ b/src/data/common.rs
@@ -77,7 +77,7 @@ pub struct Money {
 macro_rules! impl_money {
     ($name:ident, $type:expr) => {
         #[doc=concat!("Creates a instance of Money with the currency ", stringify!($type))]
-        pub fn $name(value: &str) -> Self {
+        pub fn $name(value: impl ToString) -> Self {
             Self {
                 currency_code: $type,
                 value: value.to_string(),


### PR DESCRIPTION
This change allows the constructors like `Money::eur()` to be called with anything that can be converted to String. Otherwise an unnecessary second String allocation would be needed if you already had a String.