### PR TITLE
Fix `Order` parsing error

### DIFF
--- a/src/data/orders.rs
+++ b/src/data/orders.rs
@@ -215,12 +215,19 @@ impl Default for ItemCategoryType {
     }
 }
 
+#[skip_serializing_none]
+#[derive(Debug, Default, Serialize, Deserialize, Clone)]
+pub struct ShippingDetailName {
+    /// The name of the person to whom to ship the items. Supports only the full_name property.
+    pub full_name: String,
+}
+
 /// The name and address of the person to whom to ship the items.
 #[skip_serializing_none]
 #[derive(Debug, Default, Serialize, Deserialize, Clone)]
 pub struct ShippingDetail {
     /// The name of the person to whom to ship the items. Supports only the full_name property.
-    pub name: Option<String>,
+    pub name: Option<ShippingDetailName>,
     /// The address of the person to whom to ship the items.
     pub address: Option<Address>,
 }

--- a/src/data/orders.rs
+++ b/src/data/orders.rs
@@ -215,6 +215,7 @@ impl Default for ItemCategoryType {
     }
 }
 
+/// The name of the person to whom to ship the items.
 #[skip_serializing_none]
 #[derive(Debug, Default, Serialize, Deserialize, Clone)]
 pub struct ShippingDetailName {


### PR DESCRIPTION
Currently, the `Order` struct is not entirely aligned with Paypal API reference. Specifically, the name field of "shipping_detail" object is an object instead of a string per https://developer.paypal.com/docs/api/orders/v2/#definition-shipping_detail.

This inconsistency causes parsing errors in capturing order

This PR fixed the above error and worked perfectly under my testing case in PayPal sandbox.