### PR TITLE
Update the capture response structures

### DIFF
--- a/src/data/orders.rs
+++ b/src/data/orders.rs
@@ -716,13 +716,27 @@ pub struct WalletResponse {
     pub apple_pay: CardResponse,
 }
 
+/// The paypal account used to fund the transaction.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct PaypalPaymentSourceResponse {
+    /// The name of the payer.
+    pub name: PayerName,
+    /// The email address of the payer.
+    pub email_address: String,
+    /// The account id of the payer.
+    pub account_id: String,
+}
+
 /// The payment source used to fund the payment.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct PaymentSourceResponse {
     /// The payment card to use to fund a payment. Card can be a credit or debit card
-    pub card: CardResponse,
+    pub card: Option<CardResponse>,
     /// The customer's wallet used to fund the transaction.
-    pub wallet: WalletResponse,
+    pub wallet: Option<WalletResponse>,
+
+    /// The paypal account used to fund the transaction.
+    pub paypal: Option<PaypalPaymentSourceResponse>,
 }
 
 /// The status of an order.


### PR DESCRIPTION
Since today I've started receiving a somewhat strange reply from paypal on order capture, here is the excerpt that causes deserialization error:
```json
{
...
  "payment_source": {
    "paypal": {
      "email_address": "email@address.com",
      "account_id": "58XXXXXXXX",
      "name": {
        "given_name": "Test",
        "surname": "Test"
      },
      "address": {
        "country_code": "US"
      }
    }
  },
...
```
This field is not documented except in the response samples on the PayPal docs site. I've added them still and accounted for the fact that other fields in that structure can be missing.