### PR TITLE
Make get_access_token take &self

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ async fn main() {
     let clientid = std::env::var("PAYPAL_CLIENTID").unwrap();
     let secret = std::env::var("PAYPAL_SECRET").unwrap();
 
-    let mut client = Client::new(clientid, secret, PaypalEnv::Sandbox);
+    let client = Client::new(clientid, secret, PaypalEnv::Sandbox);
 
     client.get_access_token().await.unwrap();
 

--- a/examples/invoice.rs
+++ b/examples/invoice.rs
@@ -11,7 +11,7 @@ async fn main() -> Result<()> {
     let clientid = std::env::var("PAYPAL_CLIENTID")?;
     let secret = std::env::var("PAYPAL_SECRET")?;
 
-    let mut client = Client::new(clientid, secret, PaypalEnv::Sandbox);
+    let client = Client::new(clientid, secret, PaypalEnv::Sandbox);
     client.get_access_token().await?;
 
     let payload = InvoicePayloadBuilder::default()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,7 @@
 //!     let clientid = std::env::var("PAYPAL_CLIENTID").unwrap();
 //!     let secret = std::env::var("PAYPAL_SECRET").unwrap();
 //!
-//!     let mut client = Client::new(clientid, secret, PaypalEnv::Sandbox);
+//!     let client = Client::new(clientid, secret, PaypalEnv::Sandbox);
 //!
 //!     client.get_access_token().await.unwrap();
 //!

--- a/tests/auth_tests.rs
+++ b/tests/auth_tests.rs
@@ -27,7 +27,7 @@ async fn test_auth() -> color_eyre::Result<()> {
         .mount(&mock_server)
         .await;
 
-    let mut client = create_client(&mock_server.uri());
+    let client = create_client(&mock_server.uri());
 
     client.get_access_token().await?;
 

--- a/tests/orders_tests.rs
+++ b/tests/orders_tests.rs
@@ -42,7 +42,7 @@ async fn test_create_order() -> color_eyre::Result<()> {
         .mount(&mock_server)
         .await;
 
-    let mut client = create_client(&mock_server.uri());
+    let client = create_client(&mock_server.uri());
 
     client.get_access_token().await?;
 


### PR DESCRIPTION
#### What is being changed?
This PR changes `Client::get_access_token(&mut self)` to `Client::get_access_token(&self)` by wrapping  `access_token` and `expires` fields on `Auth` in `Arc<RwLock<>>`.

#### Why?
Using `Client` becomes more ergonomic in many async situations. For example in web frameworks like `axum` or `poem` you only get shared references to your state, which is where you would probably store your `Client`.